### PR TITLE
Consecutive time issue

### DIFF
--- a/app/d/activity/add-activity.tsx
+++ b/app/d/activity/add-activity.tsx
@@ -42,14 +42,6 @@ export default function AddActivityButton() {
     if(time.length <= 0) {
       return dispatch(setNotification({ type: "error", text: "시간을 선택하세요" }));
     }
-    if (time.length > 1) {
-      const sortedTime = [...time].sort((a, b) => a - b);
-      for (let i = 1; i < sortedTime.length; i++) {
-        if (sortedTime[i] !== sortedTime[i - 1] + 1) {
-          return dispatch(setNotification({ type: "error", text: "시간은 연속적이어야 해요" }));
-        }
-      }
-    }
     if(!place) {
       return dispatch(setNotification({ type: "error", text: "장소를 선택하세요" }));
     }

--- a/app/d/activity/all/list.tsx
+++ b/app/d/activity/all/list.tsx
@@ -10,7 +10,7 @@ import Modal from "@components/modal";
 import { AnimatePresence } from "framer-motion";
 import Link from "next/link";
 import { useAppSelector } from "@libs/client/redux/hooks";
-import displayPerio from "@libs/client/perio-display";
+import { formatPerioRange } from "@libs/client/perio-display";
 
 export default function ActivityList() {
 
@@ -151,36 +151,7 @@ export default function ActivityList() {
                             "$1년 $2월 $3일"
                             )
                           : ""}<br/>
-                          {(() => {
-                            if (!activity.perio) return "";
-                            const sorted = activity.perio
-                              .split(',')
-                              .map((p: string) => parseInt(p.trim(), 10))
-                              .filter((n: number) => !isNaN(n))
-                              .sort((a: number, b: number) => a - b);
-                            if (sorted.length === 0) return "";
-                            const groups: number[][] = [];
-                            let currentGroup: number[] = [sorted[0]];
-                            for (let i = 1; i < sorted.length; i++) {
-                              if (sorted[i] === sorted[i - 1] + 1) {
-                                currentGroup.push(sorted[i]);
-                              } else {
-                                groups.push(currentGroup);
-                                currentGroup = [sorted[i]];
-                              }
-                            }
-                            groups.push(currentGroup);
-                            return groups
-                              .map((group) => {
-                                if (group.length === 1) {
-                                  return displayPerio(group[0], undefined, activity.date);
-                                }
-                                const start = displayPerio(group[0], undefined, activity.date);
-                                const end = displayPerio(group[group.length - 1], undefined, activity.date);
-                                return `${start} ~ ${end}`;
-                              })
-                              .join(', ');
-                          })()}
+                          { formatPerioRange(activity.perio, activity.date) }
                         </td>
                       </tr>
                     )
@@ -310,36 +281,7 @@ export default function ActivityList() {
                             )
                           : ""}
                           <br/>
-                          {(() => {
-                            if (!activity.perio) return "";
-                            const sorted = activity.perio
-                              .split(',')
-                              .map((p: string) => parseInt(p.trim(), 10))
-                              .filter((n: number) => !isNaN(n))
-                              .sort((a: number, b: number) => a - b);
-                            if (sorted.length === 0) return "";
-                            const groups: number[][] = [];
-                            let currentGroup: number[] = [sorted[0]];
-                            for (let i = 1; i < sorted.length; i++) {
-                              if (sorted[i] === sorted[i - 1] + 1) {
-                                currentGroup.push(sorted[i]);
-                              } else {
-                                groups.push(currentGroup);
-                                currentGroup = [sorted[i]];
-                              }
-                            }
-                            groups.push(currentGroup);
-                            return groups
-                              .map((group) => {
-                                if (group.length === 1) {
-                                  return displayPerio(group[0], undefined, activity.date);
-                                }
-                                const start = displayPerio(group[0], undefined, activity.date);
-                                const end = displayPerio(group[group.length - 1], undefined, activity.date);
-                                return `${start} ~ ${end}`;
-                              })
-                              .join(', ');
-                          })()}
+                          { formatPerioRange(activity.perio, activity.date) }
                         </td>
                       </tr>
                     )

--- a/app/d/activity/all/list.tsx
+++ b/app/d/activity/all/list.tsx
@@ -151,9 +151,36 @@ export default function ActivityList() {
                             "$1년 $2월 $3일"
                             )
                           : ""}<br/>
-                          {displayPerio(+activity.perio.split(',').sort()[0], undefined, activity.date)}
-                          {' ~ '}
-                          {displayPerio(+activity.perio.split(',').sort(function (a:number, b:number) {return b - a;})[0], undefined, activity.date)}
+                          {(() => {
+                            if (!activity.perio) return "";
+                            const sorted = activity.perio
+                              .split(',')
+                              .map((p: string) => parseInt(p.trim(), 10))
+                              .filter((n: number) => !isNaN(n))
+                              .sort((a: number, b: number) => a - b);
+                            if (sorted.length === 0) return "";
+                            const groups: number[][] = [];
+                            let currentGroup: number[] = [sorted[0]];
+                            for (let i = 1; i < sorted.length; i++) {
+                              if (sorted[i] === sorted[i - 1] + 1) {
+                                currentGroup.push(sorted[i]);
+                              } else {
+                                groups.push(currentGroup);
+                                currentGroup = [sorted[i]];
+                              }
+                            }
+                            groups.push(currentGroup);
+                            return groups
+                              .map((group) => {
+                                if (group.length === 1) {
+                                  return displayPerio(group[0], undefined, activity.date);
+                                }
+                                const start = displayPerio(group[0], undefined, activity.date);
+                                const end = displayPerio(group[group.length - 1], undefined, activity.date);
+                                return `${start} ~ ${end}`;
+                              })
+                              .join(', ');
+                          })()}
                         </td>
                       </tr>
                     )
@@ -283,9 +310,36 @@ export default function ActivityList() {
                             )
                           : ""}
                           <br/>
-                          {displayPerio(+activity.perio.split(',').sort()[0], undefined, activity.date)}
-                          {' ~ '}
-                          {displayPerio(+activity.perio.split(',').sort(function (a:number, b:number) {return b - a;})[0], undefined, activity.date)}
+                          {(() => {
+                            if (!activity.perio) return "";
+                            const sorted = activity.perio
+                              .split(',')
+                              .map((p: string) => parseInt(p.trim(), 10))
+                              .filter((n: number) => !isNaN(n))
+                              .sort((a: number, b: number) => a - b);
+                            if (sorted.length === 0) return "";
+                            const groups: number[][] = [];
+                            let currentGroup: number[] = [sorted[0]];
+                            for (let i = 1; i < sorted.length; i++) {
+                              if (sorted[i] === sorted[i - 1] + 1) {
+                                currentGroup.push(sorted[i]);
+                              } else {
+                                groups.push(currentGroup);
+                                currentGroup = [sorted[i]];
+                              }
+                            }
+                            groups.push(currentGroup);
+                            return groups
+                              .map((group) => {
+                                if (group.length === 1) {
+                                  return displayPerio(group[0], undefined, activity.date);
+                                }
+                                const start = displayPerio(group[0], undefined, activity.date);
+                                const end = displayPerio(group[group.length - 1], undefined, activity.date);
+                                return `${start} ~ ${end}`;
+                              })
+                              .join(', ');
+                          })()}
                         </td>
                       </tr>
                     )

--- a/app/d/activity/list.tsx
+++ b/app/d/activity/list.tsx
@@ -17,6 +17,37 @@ import Loading from "@components/loading";
 import displayPerio, { isWeekend } from "@libs/client/perio-display";
 import PasscardModal from "@components/info/passcard";
 
+function formatPerioRange(perio: string, date: string) {
+  if (!perio) return "";
+  const sorted = perio
+    .split(',')
+    .map((p: string) => parseInt(p.trim(), 10))
+    .filter((n: number) => !isNaN(n))
+    .sort((a: number, b: number) => a - b);
+  if (sorted.length === 0) return "";
+  const groups: number[][] = [];
+  let currentGroup: number[] = [sorted[0]];
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] === sorted[i - 1] + 1) {
+      currentGroup.push(sorted[i]);
+    } else {
+      groups.push(currentGroup);
+      currentGroup = [sorted[i]];
+    }
+  }
+  groups.push(currentGroup);
+  return groups
+    .map((group) => {
+      if (group.length === 1) {
+        return displayPerio(group[0], undefined, date);
+      }
+      const start = displayPerio(group[0], undefined, date);
+      const end = displayPerio(group[group.length - 1], undefined, date);
+      return `${start} ~ ${end}`;
+    })
+    .join(', ');
+}
+
 export default function ActivityList() {
 
   const [search, setSearch] = useState("");
@@ -250,36 +281,7 @@ export default function ActivityList() {
                             )
                           : ""}
                           <br/>
-                          {(() => {
-                            if (!activity.perio) return "";
-                            const sorted = activity.perio
-                              .split(',')
-                              .map((p: string) => parseInt(p.trim(), 10))
-                              .filter((n: number) => !isNaN(n))
-                              .sort((a: number, b: number) => a - b);
-                            if (sorted.length === 0) return "";
-                            const groups: number[][] = [];
-                            let currentGroup: number[] = [sorted[0]];
-                            for (let i = 1; i < sorted.length; i++) {
-                              if (sorted[i] === sorted[i - 1] + 1) {
-                                currentGroup.push(sorted[i]);
-                              } else {
-                                groups.push(currentGroup);
-                                currentGroup = [sorted[i]];
-                              }
-                            }
-                            groups.push(currentGroup);
-                            return groups
-                              .map((group) => {
-                                if (group.length === 1) {
-                                  return displayPerio(group[0], undefined, activity.date);
-                                }
-                                const start = displayPerio(group[0], undefined, activity.date);
-                                const end = displayPerio(group[group.length - 1], undefined, activity.date);
-                                return `${start} ~ ${end}`;
-                              })
-                              .join(', ');
-                          })()}
+                          { formatPerioRange(activity.perio, activity.date) }
                         </td>
                         { userInfo.type === 1 && <td className="px-6 py-2 w-[40px]">
                           <div className="bg-blue-500/20 hover:bg-blue-600/20 text-sm transition-all font-bold justify-center px-3 py-3 flex items-center cursor-pointer rounded-[10px] text-blue-500" onClick={(e) => {
@@ -465,36 +467,7 @@ export default function ActivityList() {
                             )
                           : ""}
                           <br/>
-                          {(() => {
-                            if (!activity.perio) return "";
-                            const sorted = activity.perio
-                              .split(',')
-                              .map((p: string) => parseInt(p.trim(), 10))
-                              .filter((n: number) => !isNaN(n))
-                              .sort((a: number, b: number) => a - b);
-                            if (sorted.length === 0) return "";
-                            const groups: number[][] = [];
-                            let currentGroup: number[] = [sorted[0]];
-                            for (let i = 1; i < sorted.length; i++) {
-                              if (sorted[i] === sorted[i - 1] + 1) {
-                                currentGroup.push(sorted[i]);
-                              } else {
-                                groups.push(currentGroup);
-                                currentGroup = [sorted[i]];
-                              }
-                            }
-                            groups.push(currentGroup);
-                            return groups
-                              .map((group) => {
-                                if (group.length === 1) {
-                                  return displayPerio(group[0], undefined, activity.date);
-                                }
-                                const start = displayPerio(group[0], undefined, activity.date);
-                                const end = displayPerio(group[group.length - 1], undefined, activity.date);
-                                return `${start} ~ ${end}`;
-                              })
-                              .join(', ');
-                          })()}
+                          { formatPerioRange(activity.perio, activity.date) }
                         </td>
                       </tr>
                     )

--- a/app/d/activity/list.tsx
+++ b/app/d/activity/list.tsx
@@ -250,9 +250,36 @@ export default function ActivityList() {
                             )
                           : ""}
                           <br/>
-                          {displayPerio(+activity.perio.split(',').sort()[0], undefined, activity.date)}
-                          {' ~ '}
-                          {displayPerio(+activity.perio.split(',').sort(function (a:number, b:number) {return b - a;})[0], undefined, activity.date)}
+                          {(() => {
+                            if (!activity.perio) return "";
+                            const sorted = activity.perio
+                              .split(',')
+                              .map((p: string) => parseInt(p.trim(), 10))
+                              .filter((n: number) => !isNaN(n))
+                              .sort((a: number, b: number) => a - b);
+                            if (sorted.length === 0) return "";
+                            const groups: number[][] = [];
+                            let currentGroup: number[] = [sorted[0]];
+                            for (let i = 1; i < sorted.length; i++) {
+                              if (sorted[i] === sorted[i - 1] + 1) {
+                                currentGroup.push(sorted[i]);
+                              } else {
+                                groups.push(currentGroup);
+                                currentGroup = [sorted[i]];
+                              }
+                            }
+                            groups.push(currentGroup);
+                            return groups
+                              .map((group) => {
+                                if (group.length === 1) {
+                                  return displayPerio(group[0], undefined, activity.date);
+                                }
+                                const start = displayPerio(group[0], undefined, activity.date);
+                                const end = displayPerio(group[group.length - 1], undefined, activity.date);
+                                return `${start} ~ ${end}`;
+                              })
+                              .join(', ');
+                          })()}
                         </td>
                         { userInfo.type === 1 && <td className="px-6 py-2 w-[40px]">
                           <div className="bg-blue-500/20 hover:bg-blue-600/20 text-sm transition-all font-bold justify-center px-3 py-3 flex items-center cursor-pointer rounded-[10px] text-blue-500" onClick={(e) => {
@@ -438,9 +465,36 @@ export default function ActivityList() {
                             )
                           : ""}
                           <br/>
-                          {displayPerio(+activity.perio.split(',').sort()[0], undefined, activity.date)}
-                          {' ~ '}
-                          {displayPerio(+activity.perio.split(',').sort(function (a:number, b:number) {return b - a;})[0], undefined, activity.date)}
+                          {(() => {
+                            if (!activity.perio) return "";
+                            const sorted = activity.perio
+                              .split(',')
+                              .map((p: string) => parseInt(p.trim(), 10))
+                              .filter((n: number) => !isNaN(n))
+                              .sort((a: number, b: number) => a - b);
+                            if (sorted.length === 0) return "";
+                            const groups: number[][] = [];
+                            let currentGroup: number[] = [sorted[0]];
+                            for (let i = 1; i < sorted.length; i++) {
+                              if (sorted[i] === sorted[i - 1] + 1) {
+                                currentGroup.push(sorted[i]);
+                              } else {
+                                groups.push(currentGroup);
+                                currentGroup = [sorted[i]];
+                              }
+                            }
+                            groups.push(currentGroup);
+                            return groups
+                              .map((group) => {
+                                if (group.length === 1) {
+                                  return displayPerio(group[0], undefined, activity.date);
+                                }
+                                const start = displayPerio(group[0], undefined, activity.date);
+                                const end = displayPerio(group[group.length - 1], undefined, activity.date);
+                                return `${start} ~ ${end}`;
+                              })
+                              .join(', ');
+                          })()}
                         </td>
                       </tr>
                     )

--- a/app/d/activity/list.tsx
+++ b/app/d/activity/list.tsx
@@ -14,39 +14,8 @@ import errorMessage from "@libs/client/error-message";
 import { useAppDispatch, useAppSelector } from "@libs/client/redux/hooks";
 import Button, { SubButton } from "@components/button";
 import Loading from "@components/loading";
-import displayPerio, { isWeekend } from "@libs/client/perio-display";
+import displayPerio, { isWeekend, formatPerioRange } from "@libs/client/perio-display";
 import PasscardModal from "@components/info/passcard";
-
-function formatPerioRange(perio: string, date: string) {
-  if (!perio) return "";
-  const sorted = perio
-    .split(',')
-    .map((p: string) => parseInt(p.trim(), 10))
-    .filter((n: number) => !isNaN(n))
-    .sort((a: number, b: number) => a - b);
-  if (sorted.length === 0) return "";
-  const groups: number[][] = [];
-  let currentGroup: number[] = [sorted[0]];
-  for (let i = 1; i < sorted.length; i++) {
-    if (sorted[i] === sorted[i - 1] + 1) {
-      currentGroup.push(sorted[i]);
-    } else {
-      groups.push(currentGroup);
-      currentGroup = [sorted[i]];
-    }
-  }
-  groups.push(currentGroup);
-  return groups
-    .map((group) => {
-      if (group.length === 1) {
-        return displayPerio(group[0], undefined, date);
-      }
-      const start = displayPerio(group[0], undefined, date);
-      const end = displayPerio(group[group.length - 1], undefined, date);
-      return `${start} ~ ${end}`;
-    })
-    .join(', ');
-}
 
 export default function ActivityList() {
 

--- a/app/login/login.tsx
+++ b/app/login/login.tsx
@@ -29,7 +29,7 @@ function LoginContainer() {
 const Login: NextPage = () => {
   const pathname = useSearchParams();
   const rawCallbackUrl = pathname.get('callbackUrl');
-  const callbackUrl = getSafeCallbackUrl(rawCallbackUrl);
+const callbackUrl = encodeURIComponent(getSafeCallbackUrl(rawCallbackUrl));
   const error = pathname.get('error');
   const dispatch = useDispatch();
 

--- a/app/login/login.tsx
+++ b/app/login/login.tsx
@@ -12,12 +12,6 @@ import Input from '@components/input';
 import Button from '@components/button';
 import Link from 'next/link';
 
-function getSafeCallbackUrl(url: string | null): string {
-  if (!url || url === 'undefined' || url === 'null') return '/d/home';
-  if (!url.startsWith('/') || url.startsWith('//')) return '/d/home';
-  return url;
-}
-
 function LoginContainer() {
   return (
     <Suspense>
@@ -28,8 +22,7 @@ function LoginContainer() {
 
 const Login: NextPage = () => {
   const pathname = useSearchParams();
-  const rawCallbackUrl = pathname.get('callbackUrl');
-const callbackUrl = encodeURIComponent(getSafeCallbackUrl(rawCallbackUrl));
+  const callbackUrl = pathname.get('callbackUrl');
   const error = pathname.get('error');
   const dispatch = useDispatch();
 

--- a/app/login/login.tsx
+++ b/app/login/login.tsx
@@ -12,6 +12,12 @@ import Input from '@components/input';
 import Button from '@components/button';
 import Link from 'next/link';
 
+function getSafeCallbackUrl(url: string | null): string {
+  if (!url || url === 'undefined' || url === 'null') return '/d/home';
+  if (!url.startsWith('/') || url.startsWith('//')) return '/d/home';
+  return url;
+}
+
 function LoginContainer() {
   return (
     <Suspense>
@@ -22,7 +28,8 @@ function LoginContainer() {
 
 const Login: NextPage = () => {
   const pathname = useSearchParams();
-  const callbackUrl = pathname.get('callbackUrl');
+  const rawCallbackUrl = pathname.get('callbackUrl');
+  const callbackUrl = getSafeCallbackUrl(rawCallbackUrl);
   const error = pathname.get('error');
   const dispatch = useDispatch();
 

--- a/app/login/success/success.tsx
+++ b/app/login/success/success.tsx
@@ -10,6 +10,12 @@ import { Suspense, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux';
 import Loading from '@components/loading';
 
+function getSafeCallbackUrl(url: string | null): string {
+  if (!url || url === 'undefined' || url === 'null') return '/d/home';
+  if (!url.startsWith('/') || url.startsWith('//')) return '/d/home';
+  return url;
+}
+
 function SuccessContainer() {
   return (
     <Suspense>
@@ -22,12 +28,11 @@ const Success: NextPage = () => {
   const { data } = useSWR('/api/user');
 
   const router = useSearchParams();
-  const callbackUrl = router.get('callbackUrl');
+  const rawCallbackUrl = router.get('callbackUrl');
 
   useEffect(() => {
     if(data?.success === true) {
-      if(callbackUrl && callbackUrl !== "undefined" && callbackUrl !== "null") location.href = callbackUrl;
-      else location.href = "/d/home";
+      location.href = getSafeCallbackUrl(rawCallbackUrl);
     } else {
       if(data?.message === '사용자 정보를 찾을 수 없어요' || data?.message === 'Unauthorized') {
         location.href = "/login/error";

--- a/app/login/success/success.tsx
+++ b/app/login/success/success.tsx
@@ -10,12 +10,6 @@ import { Suspense, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux';
 import Loading from '@components/loading';
 
-function getSafeCallbackUrl(url: string | null): string {
-  if (!url || url === 'undefined' || url === 'null') return '/d/home';
-  if (!url.startsWith('/') || url.startsWith('//')) return '/d/home';
-  return url;
-}
-
 function SuccessContainer() {
   return (
     <Suspense>
@@ -28,11 +22,12 @@ const Success: NextPage = () => {
   const { data } = useSWR('/api/user');
 
   const router = useSearchParams();
-  const rawCallbackUrl = router.get('callbackUrl');
+  const callbackUrl = router.get('callbackUrl');
 
   useEffect(() => {
     if(data?.success === true) {
-      location.href = getSafeCallbackUrl(rawCallbackUrl);
+      if(callbackUrl && callbackUrl !== "undefined" && callbackUrl !== "null") location.href = callbackUrl;
+      else location.href = "/d/home";
     } else {
       if(data?.message === '사용자 정보를 찾을 수 없어요' || data?.message === 'Unauthorized') {
         location.href = "/login/error";

--- a/libs/client/perio-display.tsx
+++ b/libs/client/perio-display.tsx
@@ -17,6 +17,37 @@ export function isWeekend(date?: Date | string) {
   return day === 0 || day === 6; // 0: 일요일, 6: 토요일
 };
 
+export function formatPerioRange(perio: string, date: string): string {
+  if (!perio) return "";
+  const sorted = perio
+    .split(',')
+    .map((p: string) => parseInt(p.trim(), 10))
+    .filter((n: number) => !isNaN(n))
+    .sort((a: number, b: number) => a - b);
+  if (sorted.length === 0) return "";
+  const groups: number[][] = [];
+  let currentGroup: number[] = [sorted[0]];
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] === sorted[i - 1] + 1) {
+      currentGroup.push(sorted[i]);
+    } else {
+      groups.push(currentGroup);
+      currentGroup = [sorted[i]];
+    }
+  }
+  groups.push(currentGroup);
+  return groups
+    .map((group) => {
+      if (group.length === 1) {
+        return displayPerio(group[0], undefined, date);
+      }
+      const start = displayPerio(group[0], undefined, date);
+      const end = displayPerio(group[group.length - 1], undefined, date);
+      return `${start} ~ ${end}`;
+    })
+    .join(', ');
+}
+
 export default function displayPerio(perio:number, type?:number, date?:Date | string):string {
   if (isWeekend(date)) {
     // 주말: perio 1~4

--- a/libs/client/perio-display.tsx
+++ b/libs/client/perio-display.tsx
@@ -17,7 +17,7 @@ export function isWeekend(date?: Date | string) {
   return day === 0 || day === 6; // 0: 일요일, 6: 토요일
 };
 
-export function formatPerioRange(perio: string, date: string): string {
+export function formatPerioRange(perio?: string, date?: Date | string): string {
   if (!perio) return "";
   const sorted = perio
     .split(',')


### PR DESCRIPTION
~~[Feature] app/login/login.tsx~~
~~- 함수를 하나 정의함~~
~~- callbackURL이 비어있거나 'undefined'거나 'null'이면 그냥 홈 화면(/d/home) 반환~~
~~- callbackURL이 /로 시작하지 않거나 //로 시작한다면 홈 화면 반환~~
~~- 암튼 로그인 시 callbackURL을 이 함수로 감싸서 open redirect 공격을 방어할 것.~~

~~[Feature] app/login/success/success.tsx~~
~~- 위와 똑같은 기능~~

~~[comment]~~
~~- 사실 이 기능은 별 쓸데없는거긴 합니다. 서버 자체가 폐쇠망에 있기도 하고 저희 학교에 open redirect 공격을 할 만한 사람은 없다고 믿습니다. 뭐 근데 보안 관련 문제는 미리미리 해결해서 나쁠건 없다 생각합니다.~~
~~- 위 설명을 보면 아시겠지만 login과 success에 동일한 기능이 들어갔습니다. 원래 sucess에만 들어가도 상관은 없지만 혹시 몰라 login에도 넣어놨습니다. 이 부분에 대해선 여러분의 의견을 들어보도록하겠습니다.~~
~~- callbackURL을 거르는 기준은 학교에 가서 callbackURL이 어떤식으로 되는지 알아야지 정확하게 할 수 있을 것 같습니다. 일단 callbackURL을 /d/home 이런식으로 된다고 가정하고 코드를 짰습니다.~~

예상 한거랑 서비스랑 좀 달라서 구현이 좀 빡세네요 롤백하겠습니다.

추가적으로 불연속적인 시간으로 활승을 쓸 수 없는 문제를 해결했습니다.
app/d/activity/add-activity.tsx : 시간이 불연속적이면 '시간은 연속적이여야 해요.' 라는 메세지를 띄우는 로직을 제거
app/d/activity/list.tsx와 app/d/activity/all/list.tsx : 함수 적용
libs/client/perio-display.tsx : 연속적인 시간에 대해서는 ~로 연결, 불연속적인 시간에 대해서는 ,로 연결하는 코드를 추가
- 아무래도 활동 시간이 7교시 ~ 8교시, 야자 2교시 ~ 야자 3교시 이렇게 길게 되기 때문에 UI가 조금 밀리는 현상이 발생합니다.